### PR TITLE
Implement pinned news posts

### DIFF
--- a/data/News/2021-05-05-call-for-proposals.md
+++ b/data/News/2021-05-05-call-for-proposals.md
@@ -1,6 +1,7 @@
 ---
 title: Call for Proposals now open!
 published: 2021-05-05
+pinned: True
 ---
 
 We are thrilled to announce for call for proposals (CFP) is now open!

--- a/models/News.yml
+++ b/models/News.yml
@@ -2,3 +2,5 @@ title: String
 content: Content
 published: DateTime
 ytid: String
+
+pinned: Boolean

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,7 +17,7 @@
 </header>
 {% endblock %}
 {% block main %}
-{{ m.news(latest_news) }}
+{% if pinned_item %}{{m.news(pinned_item)}}{%else%}{{ m.news(latest_news) }}{%endif%}
 <br>
 <a href="/news">Read more news posts</a>
 {% endblock %}

--- a/templates/news_index.html
+++ b/templates/news_index.html
@@ -8,7 +8,7 @@
         <p>
             <a href="{% url "news_post", post %}">{{ post.title }}</a>
             <br />
-            {%- if loop.first -%}<b>Latest News</b> &mdash; {% endif %}<small>Published {{ post.published.strftime("%d %B, %Y") }}</small>
+            {%- if loop.first -%}<b>Latest News</b> &mdash; {% endif %}{% if post.pinned %}📌 &mdash; {%endif%}<small>Published {{ post.published.strftime("%d %B, %Y") }}</small>
         </p>
     </li>
     {% endfor %}

--- a/views/home.yml
+++ b/views/home.yml
@@ -3,3 +3,5 @@ template: home
 context:
   dynamic:
     latest_news: session.query(News).order_by(News.published.desc()).first()
+    pinned_item: session.query(News).filter(News.pinned == True).order_by(News.published.desc()).first()
+


### PR DESCRIPTION
Fixes #44 

Allows for pinning of news items to the front page. Currently only the most recent pinned item is displayed
Added feature: news listings shows which/if any posts are pinned. 