### PR TITLE
Add .cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ assets/build/
 data/SpeakerPack/*
 !data/SpeakerPack/_template.md.j2
 node_modules
+.cache/


### PR DESCRIPTION
The [infrastructure doc](https://github.com/pyconau/2021-website/blob/fdfd684a6c82db022b9d8fdd9fb1ae0e31c4798a/infrastructure.md) says that the `.cache` directory is in `.gitignore`, but it wasn't.

This adds it to gitignore to bring reality to the same plane of existence as the doc.