### PR TITLE
Make TypeScript happy

### DIFF
--- a/frontend/backstage.ts
+++ b/frontend/backstage.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon"
+import { DateTime, DateTimeFormatOptions } from "luxon"
 
 const backstageBar = document.createElement("template")
 backstageBar.innerHTML = `
@@ -14,7 +14,7 @@ reltimeSpan.innerHTML = `
 </span>
 `
 
-const TIME_COMPACT = {
+const TIME_COMPACT: DateTimeFormatOptions = {
   weekday: "short",
   day: "2-digit",
   hour: "2-digit",
@@ -23,14 +23,14 @@ const TIME_COMPACT = {
   timeZoneName: "short",
   hour12: false,
 }
-const TIME_COMPACT_MEL = { ...TIME_COMPACT, timeZone: "Australia/Melbourne" }
-const TIME_HRMIN = {
+const TIME_COMPACT_MEL: DateTimeFormatOptions = { ...TIME_COMPACT, timeZone: "Australia/Melbourne" }
+const TIME_HRMIN: DateTimeFormatOptions = {
   hour: "2-digit",
   minute: "2-digit",
   timeZoneName: "short",
   hour12: false,
 }
-const TIME_HRMIN_MEL = { ...TIME_HRMIN, timeZone: "Australia/Melbourne" }
+const TIME_HRMIN_MEL: DateTimeFormatOptions = { ...TIME_HRMIN, timeZone: "Australia/Melbourne" }
 
 function clockTick(output: HTMLElement) {
   const now = DateTime.local()

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,21 +1,8 @@
-import { DateTime, LocalZone, Settings } from "luxon"
+import { DateTime, Settings } from "luxon"
 import backstage from "./backstage"
 import program from "./program"
 
 Settings.defaultLocale = "en-AU"
-
-const FORMATTER_DIFF_DAY = Intl.DateTimeFormat("en-au", {
-  weekday: "short",
-  hour: "numeric",
-  minute: "numeric",
-  timeZoneName: "short",
-})
-
-const FORMATTER_SAME_DAY = Intl.DateTimeFormat("en-au", {
-  hour: "numeric",
-  minute: "numeric",
-  timeZoneName: "short",
-})
 
 function onload() {
   backstage()

--- a/frontend/program.ts
+++ b/frontend/program.ts
@@ -1,16 +1,16 @@
-import { DateTime, LocalZone, DateTimeFormatOptions } from "luxon"
+import { DateTime, DateTimeFormatOptions, SystemZone } from "luxon"
 
 const ZONE = "Australia/Melbourne"
 const TIME_ONLY: DateTimeFormatOptions = {
   hour: "numeric",
   minute: "numeric",
 }
-const TIME_ONLY_DIFF_DAY = { ...TIME_ONLY, weekday: "short" }
-const TIME_ONLY_TZ = { ...TIME_ONLY, timeZoneName: "short" }
-const TIME_ONLY_AEST = { ...TIME_ONLY, timeZone: "Australia/Melbourne" }
+const TIME_ONLY_DIFF_DAY: DateTimeFormatOptions = { ...TIME_ONLY, weekday: "short" }
+const TIME_ONLY_TZ: DateTimeFormatOptions = { ...TIME_ONLY, timeZoneName: "short" }
+const TIME_ONLY_AEST = { ...TIME_ONLY, timeZone: ZONE }
 
-const HOUR_MARKER = { hour: "numeric" }
-const HOUR_MARKER_DIFF_DAY = { ...HOUR_MARKER, weekday: "short" }
+const HOUR_MARKER: DateTimeFormatOptions = { hour: "numeric" }
+const HOUR_MARKER_DIFF_DAY: DateTimeFormatOptions = { ...HOUR_MARKER, weekday: "short" }
 
 export default function scheduleInit(schedule: HTMLElement) {
   // Show local times on all time markers
@@ -81,7 +81,7 @@ export default function scheduleInit(schedule: HTMLElement) {
   schedule.appendChild(acstLabel)
   const localLabel = document.createElement("s-tz-header")
   localLabel.classList.add("local")
-  localLabel.innerText = new LocalZone().offsetName(hour.toMillis(), {
+  localLabel.innerText = SystemZone.instance.offsetName(hour.toMillis(), {
     format: "short",
   })
   schedule.appendChild(localLabel)


### PR DESCRIPTION
Fixes `Uncaught TypeError: t.LocalZone is not a constructor` on the schedule, which was preventing the local timezone label from appearing