### PR TITLE
Suppress backstage exceptions

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -5,7 +5,11 @@ import program from "./program"
 Settings.defaultLocale = "en-AU"
 
 function onload() {
-  backstage()
+  try {
+    backstage()
+  } catch (ex) {
+    console.warn("backstage error:", ex)
+  }
   const programEl = document.querySelector("s-schedule")
   if (programEl) program(programEl)
   document.querySelectorAll("time").forEach((t) => {


### PR DESCRIPTION
Firefox with Enhanced Tracking Protection on (when turned up to 11) forbids accessing `localStorage` in an iframe (raising an exception when attempting to do so).

This is a small problem for us, as this would mean that some attendees would not get our timezone conversion and updating "now" line when viewing the schedule within Venueless.