### PR TITLE
Schedule now marker fixes

### DIFF
--- a/data/Page/social.md
+++ b/data/Page/social.md
@@ -101,7 +101,7 @@ _Where_: Venueless
 
 _How to apply_:
 
-  ⚡️ **[Submit your lightning talks here](https://forms.gle/TEXGB3MiyNsoTpHj7)** ⚡️ 
+  ⚡️ <a href="https://forms.gle/TEXGB3MiyNsoTpHj7" target="_blank">**Submit your lightning talks here**</a> ⚡️ 
 
   * Additional details and requirements are detailed on the form
   * Successful applicants will be notified by the end of Saturday. 

--- a/frontend/program.ts
+++ b/frontend/program.ts
@@ -1,4 +1,4 @@
-import { DateTime, DateTimeFormatOptions, SystemZone } from "luxon"
+import { DateTime, DateTimeFormatOptions } from "luxon"
 
 const ZONE = "Australia/Melbourne"
 const TIME_ONLY: DateTimeFormatOptions = {
@@ -81,9 +81,7 @@ export default function scheduleInit(schedule: HTMLElement) {
   schedule.appendChild(acstLabel)
   const localLabel = document.createElement("s-tz-header")
   localLabel.classList.add("local")
-  localLabel.innerText = SystemZone.instance.offsetName(hour.toMillis(), {
-    format: "short",
-  })
+  localLabel.innerText = DateTime.local().offsetNameShort;
   schedule.appendChild(localLabel)
 
   // now marker

--- a/frontend/program.ts
+++ b/frontend/program.ts
@@ -45,7 +45,7 @@ export default function scheduleInit(schedule: HTMLElement) {
     console.log(hour.toLocaleString(HOUR_MARKER))
     const newTime = document.createElement("s-time")
     newTime.innerText = hour.toLocaleString(HOUR_MARKER)
-    const minute = hour.toMillis() / 60_000
+    const minute = (hour.toMillis() / 60_000).toFixed(0)
     rules.add(minute)
     newTime.style.setProperty("--at", "" + minute)
     schedule.appendChild(newTime)
@@ -63,7 +63,7 @@ export default function scheduleInit(schedule: HTMLElement) {
     )
     console.log(hourHasDifferentDay, label, hour)
     newTime.innerText = label
-    const minute = hour.toMillis() / 60_000
+    const minute = (hour.toMillis() / 60_000).toFixed(0)
     console.log(hour.toMillis(), minute)
     rules.add(minute)
     newTime.classList.add("local")
@@ -96,7 +96,7 @@ export default function scheduleInit(schedule: HTMLElement) {
       nowMarker = document.createElement("s-now-rule")
       schedule.appendChild(nowMarker)
     }
-    nowMarker.style.setProperty("--at", "" + nowMillis / 60_000)
+    nowMarker.style.setProperty("--at", "" + (nowMillis / 60_000).toFixed(0))
     window.setTimeout(updateNow, 60_000 - (nowMillis % 60_000))
   }
   const timeUntilStart = eventStart.diffNow().milliseconds

--- a/templates/program-redirect.html
+++ b/templates/program-redirect.html
@@ -3,9 +3,9 @@
     <head>
         <script type="text/javascript">
         const now = new Date().getTime();
-        if (1631282400000 < now && now < 163136880000)
+        if (1631282400000 < now && now < 1631368800)
             window.location = '/program/sat/'
-        else if (163136880000 < now && now < 163145520000)
+        else if (1631368800 < now && now < 1631455200000)
             window.location = '/program/sun/'
         else
             window.location = '/program/fri/'

--- a/templates/program-redirect.html
+++ b/templates/program-redirect.html
@@ -3,9 +3,9 @@
     <head>
         <script type="text/javascript">
         const now = new Date().getTime();
-        if (1631282400000 < now && now < 1631368800)
+        if (Number(Date.parse('10 Sep 2021 16:00:00 GMT')) < now && now < Number(Date.parse('11 Sep 2021 16:00:00 GMT')))
             window.location = '/program/sat/'
-        else if (1631368800 < now && now < 1631455200000)
+        else if (Number(Date.parse('11 Sep 2021 16:00:00 GMT')) < now && now < Number(Date.parse('12 Sep 2021 16:00:00 GMT')))
             window.location = '/program/sun/'
         else
             window.location = '/program/fri/'

--- a/templates/program-redirect.html
+++ b/templates/program-redirect.html
@@ -3,9 +3,9 @@
     <head>
         <script type="text/javascript">
         const now = new Date().getTime();
-        if (1599229800000 < now && now < 1599316200000)
+        if (1631282400000 < now && now < 163136880000)
             window.location = '/program/sat/'
-        else if (1599316200000 < now && now < 1599402600000)
+        else if (163136880000 < now && now < 163145520000)
             window.location = '/program/sun/'
         else
             window.location = '/program/fri/'

--- a/templates/program-redirect.html
+++ b/templates/program-redirect.html
@@ -1,17 +1,25 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <script type="text/javascript">
+
+<head>
+    <script type="text/javascript">
         const now = new Date().getTime();
-        if (Number(Date.parse('10 Sep 2021 16:00:00 GMT')) < now && now < Number(Date.parse('11 Sep 2021 16:00:00 GMT')))
+
+        let saturday = Number(Date.parse('10 Sep 2021 16:00:00 GMT'))
+        let sunday = Number(Date.parse('11 Sep 2021 16:00:00 GMT'))
+        let monday = Number(Date.parse('12 Sep 2021 16:00:00 GMT'))
+
+        if (saturday < now && now < sunday)
             window.location = '/program/sat/'
-        else if (Number(Date.parse('11 Sep 2021 16:00:00 GMT')) < now && now < Number(Date.parse('12 Sep 2021 16:00:00 GMT')))
+        else if (sunday < now && now < monday)
             window.location = '/program/sun/'
         else
             window.location = '/program/fri/'
-        </script>
-        <meta http-equiv="refresh" content="0;URL='/program/fri/'" />
-    </head>
-    <body>
-        See <a href="/program/fri/">/program/fri/</a>
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/program/fri/'" />
+</head>
+
+<body>
+    See <a href="/program/fri/">/program/fri/</a>
+
 </html>


### PR DESCRIPTION
* prevents scientific notation in bigints so css works to put the red 'now' marker in the correct place on the schedule
* get the local short timezone name by a method that exists