### PR TITLE
Updates /sponsor for 2022 early interest

### DIFF
--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -69,13 +69,14 @@ and of course <a href="#auspice">Linux Australia</a>!
 
 
 <h1>Sponsorship Opportunities</h1>
-<p>With the conference actively upon us, we are no longer actively reaching out for new sponsors. We're incredibly grateful to all the sponsors who've helped make 2021 such a memorable moment for our community.</p>
+<p>Thank you to all the sponsors who made PyConline AU 2021 such a memorable moment for our community.</p>
 
-<p>
-  To find out more about the sponsorship opportunities available,
-  <a href="/assets/documents/pyconlineau2021_sponsorships.pdf">download our sponsorship prospectus</a>.
-  You can reach the conference team via 
-  <a href="mailto:sponsorship@pycon.org.au">sponsorship@pycon.org.au</a> to discuss last minute sponsorship opportunities for PyConline AU 2021.
+<p>PyCon AU will run in 2022, but its format (and optimistically, location) are yet to be determined.</p>
+
+<p>If you would like to hear from us regarding early sponsorship opportunities for 2022,
+   please email <a href="mailto:sponsorship@pycon.org.au">sponsorship@pycon.org.au</a>
+   to register your interest.
 </p>
+
 {% endblock %}
 


### PR DESCRIPTION
 - removes direct links to the 2021 prospectus
 - invites early interest for 2022 sponsorship oppportunities.